### PR TITLE
Travis file now uses dist: trusty in order to select oraclejdk8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 notifications:
   email:
     on_success: always # default: change
@@ -12,18 +13,9 @@ services:
 #      - mysql-client
 
 sudo: true
-
 language: java
-
-matrix:
-  include:
-    - os: linux
-      dist: trusty
-      jdk: oraclejdk8
-    - os: linux
-      dist: xenial
-      jdk: openjdk8
-
+jdk:
+  - oraclejdk8
 # install: ant default
 before_install:
   - mkdir /home/travis/.ant

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,20 @@ services:
 #    packages:
 #      - mysql-server
 #      - mysql-client
+
 sudo: true
+
 language: java
-jdk:
-  - oraclejdk8
+
+matrix:
+  include:
+    - os: linux
+      dist: trusty
+      jdk: oraclejdk8
+    - os: linux
+      dist: xenial
+      jdk: openjdk8
+
 # install: ant default
 before_install:
   - mkdir /home/travis/.ant


### PR DESCRIPTION
This will solve issue #63.

The command `dist: trusty` has been added to `.travis.yml`.
With this the CI at least now finds the oraclejdk8, which is not available on `dist: xenial`.